### PR TITLE
Use API key from environment

### DIFF
--- a/chatbot.php
+++ b/chatbot.php
@@ -30,7 +30,7 @@ if ($userMsg === '') {
 
 
 // ====== KONFIG ======
-$apiKey = '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'; // tymczasowo w kodzie
+$apiKey = $_ENV['OPENAI_API_KEY'] ?? getenv('OPENAI_API_KEY') ?? '';
 $model  = 'gpt-5'; // ewentualnie 'gpt-4o-mini' do testów
 $fallbackModel = 'gpt-4o-mini';
 $logDir = __DIR__ . '/logs/chat';


### PR DESCRIPTION
## Summary
- replace hardcoded OpenAI API key with environment variable lookup

## Testing
- `php -l chatbot.php`


------
https://chatgpt.com/codex/tasks/task_e_68c11ae56a9483288d3163807d1127f3